### PR TITLE
Automatically include needed services and routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,35 +10,10 @@ Here is a list of things that the extension allows:
 
 ## Installation
 
-To install this extension, simply run the following in your root folder:
+To install this extension, simply run the following terminal command from your root folder:
 
 ```
 composer require bolt/users
-```
-
-Then, add the following to your `config/services.yaml` file:
-
-```yaml
-    Bolt\UsersExtension\Exclude\ProtectedListingController:
-        decorates: Bolt\Controller\Frontend\ListingController
-        arguments: ['@.inner']
-        tags: ['controller.service_arguments']
-
-    Bolt\UsersExtension\Exclude\ProtectedDetailController:
-        decorates: Bolt\Controller\Frontend\DetailController
-        arguments: ['@.inner']
-        tags: ['controller.service_arguments']
-
-    Bolt\UsersExtension\Controller\AccessAwareController:
-        tags: ['controller.service_arguments']
-```
-
-Finally, add this to `config/routes.yaml`:
-
-```yaml
-users_extension_controllers:
-    resource: '../../vendor/bolt/users/src/'
-    type: annotation
 ```
 
 ## Basic usage

--- a/config/routes.yaml
+++ b/config/routes.yaml
@@ -1,0 +1,3 @@
+users_extension_controllers:
+  resource: '../vendor/bolt/users/src/'
+  type: annotation

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -1,0 +1,13 @@
+services:
+  Bolt\UsersExtension\Exclude\ProtectedListingController:
+    decorates: Bolt\Controller\Frontend\ListingController
+    arguments: ['@.inner']
+    tags: ['controller.service_arguments']
+
+  Bolt\UsersExtension\Exclude\ProtectedDetailController:
+    decorates: Bolt\Controller\Frontend\DetailController
+    arguments: ['@.inner']
+    tags: ['controller.service_arguments']
+
+  Bolt\UsersExtension\Controller\AccessAwareController:
+    tags: ['controller.service_arguments']


### PR DESCRIPTION
By adding services to `config/services.yaml` and routes to `config/routes.yaml`, Bolt will automatically add them to the project's services and routes.

See https://github.com/bolt/core/pull/1634