### PR TITLE
Fix labels customization when $labels is passed to registration_form()

### DIFF
--- a/src/Twig/RegistrationFormExtension.php
+++ b/src/Twig/RegistrationFormExtension.php
@@ -60,7 +60,7 @@ class RegistrationFormExtension extends AbstractExtension
 
     public function getDisplayNameField(bool $withLabel, array $labels): string
     {
-        $text = in_array('displayname', $labels, true) ? $labels['displayname'] : 'Display Name';
+        $text = array_key_exists('displayname', $labels) ? $labels['displayname'] : 'Display Name';
         $label = $withLabel ? sprintf('<label for="displayname">%s</label>', $text) : '';
 
         $input = '<input type="text" id="displayname" name="displayname">';
@@ -70,7 +70,7 @@ class RegistrationFormExtension extends AbstractExtension
 
     public function getUsernameField(bool $withLabel, array $labels): string
     {
-        $text = in_array('username', $labels, true) ? $labels['username'] : 'Username';
+        $text = array_key_exists('username', $labels) ? $labels['username'] : 'Username';
         $label = $withLabel ? sprintf('<label for="username">%s</label>', $text) : '';
 
         $input = '<input type="text" id="username" name="username">';
@@ -80,7 +80,7 @@ class RegistrationFormExtension extends AbstractExtension
 
     public function getPasswordField(bool $withLabel, array $labels): string
     {
-        $text = in_array('password', $labels, true) ? $labels['password'] : 'Password';
+        $text = array_key_exists('password', $labels) ? $labels['password'] : 'Password';
         $label = $withLabel ? sprintf('<label for="password">%s</label>', $text) : '';
 
         $input = '<input type="password" id="password" name="password">';
@@ -90,7 +90,7 @@ class RegistrationFormExtension extends AbstractExtension
 
     public function getEmailField(bool $withLabel, array $labels): string
     {
-        $text = in_array('email', $labels, true) ? $labels['email'] : 'Email';
+        $text = array_key_exists('email', $labels) ? $labels['email'] : 'Email';
         $label = $withLabel ? sprintf('<label for="email">%s</label>', $text) : '';
 
         $input = '<input type="email" id="email" name="email">';
@@ -105,7 +105,7 @@ class RegistrationFormExtension extends AbstractExtension
 
     public function getSubmitButton(array $labels = []): string
     {
-        $text = in_array('submit', $labels, true) ? $labels['submit'] : 'Submit';
+        $text = array_key_exists('submit', $labels) ? $labels['submit'] : 'Submit';
 
         return sprintf('<input type="submit" value="%s">', $text);
     }


### PR DESCRIPTION
As for PR https://github.com/bolt/users/pull/16 this commit fix labels for call to twig function `registration_form('ROLE_USER', true, $labels)`