### PR TITLE
Improve user's active role identification

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ composer require bolt/users
 
 ## Basic usage
 
-To limit a a ContentType to a specific group of users, say `ROLE_MEMBER`, do the following:
+To limit a ContentType to a specific group of users, say `ROLE_MEMBER`, do the following:
 
 1. Define your user group in `config/extensions/bolt-usersextension.yaml`:
 


### PR DESCRIPTION
Currently, user's active role is identified as first value in roles list ...

Given this configuration:

```
# bolt-usersextension.yaml
groups:
    ROLE_MEMBER:
        ...
```

```
# security.yaml
security:
    role_hierarchy:
        ROLE_SUPER_MEMBER: ROLE_MEMBER
        ROLE_MEMBER: {}
        ROLE_FOO: {}
```

Given these users:
User1 roles: ROLE_SUPER_MEMBER
User2 roles: ROLE_FOO, ROLE_MEMBER


With current implementation, these users are denied access to `/profile` & `profile/edit` (at best) or even worse, code outright fails b/c no relevant contenttype was found.

This PR finds active user role by taking group roles and searching them through user's roles, returning first match.